### PR TITLE
Fixed VSCode dependency to be ^1.4.0

### DIFF
--- a/ls_client/package.json
+++ b/ls_client/package.json
@@ -5,7 +5,7 @@
     "version": "0.0.1",
     "publisher": "JonathanTurner",
     "engines": {
-        "vscode": "^1.0.0"
+        "vscode": "^1.4.0"
     },
     "categories": [
         "Languages",


### PR DESCRIPTION
[code.DocumentLink was introduced in 1.4.0.](https://github.com/Microsoft/vscode/commit/b5287d4621f07fc1fc4cb7aa97a30a1abd8ac91c) Without this change, postinstall downloads 1.0.0's vscode.d.ts which does not contain DocumentLink.

---

To clarify, the references to `code.DocumentLink` come from `vscode-languageclient@2.6.0` `lib/codeconverter.d.ts` and `lib/protocolConverter.d.ts`. So there's a TS compile error when running this extension with F5.